### PR TITLE
Update validator to only run validation on a callback function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ ssl/
 *.tfstate
 *.tfstate.backup
 
+.docker/
 .env
 ormconfig.json
 yarn-error.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,8 @@ services:
       - "3306:3306"
     volumes:
       - $DB_DATA_LOCATION:/var/lib/mysql
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - 1025:1025 # smtp server
+      - 8025:8025 # web ui

--- a/src/contracts/IValidationRule.ts
+++ b/src/contracts/IValidationRule.ts
@@ -6,4 +6,5 @@ export default interface IValidationRule {
     to?: string,
     length?: number,
     errorMessage?: string,
+    whenCallback?: Function,
 }

--- a/src/helpers/Validation/Body.ts
+++ b/src/helpers/Validation/Body.ts
@@ -22,6 +22,15 @@ export default class Body {
         for (let i = 0; i < this.rules.length; i++) {
             const rule = this.rules[i];
 
+            if (rule.whenCallback) {
+                const shouldRun = rule.whenCallback(req);
+
+                if (!shouldRun) {
+                    next();
+                    return;
+                }
+            }
+
             switch (rule.rule) {
                 case ValidationRule.NotEmpty:
                     if (!req.body[rule.field] || req.body[rule.field].length == 0) {
@@ -310,6 +319,14 @@ export default class Body {
         if (rulesLength == 0) return this;
 
         this.rules[rulesLength - 1].errorMessage = message;
+
+        return this;
+    }
+
+    public When(whenCallback: Function): Body {
+        if (this.rules.length == 0) return this;
+
+        this.rules[this.rules.length - 1].whenCallback = whenCallback;
 
         return this;
     }

--- a/src/helpers/Validation/Params.ts
+++ b/src/helpers/Validation/Params.ts
@@ -22,6 +22,15 @@ export default class Params {
         for (let i = 0; i < this.rules.length; i++) {
             const rule = this.rules[i];
 
+            if (rule.whenCallback) {
+                const shouldRun = rule.whenCallback(req);
+
+                if (!shouldRun) {
+                    next();
+                    return;
+                }
+            }
+
             switch (rule.rule) {
                 case ValidationRule.NotEmpty:
                     if (!req.params[rule.field] || req.params[rule.field].length == 0) {
@@ -241,6 +250,14 @@ export default class Params {
         if (rulesLength == 0) return this;
 
         this.rules[rulesLength - 1].errorMessage = message;
+
+        return this;
+    }
+
+    public When(whenCallback: Function): Params {
+        if (this.rules.length == 0) return this;
+
+        this.rules[this.rules.length - 1].whenCallback = whenCallback;
 
         return this;
     }

--- a/src/helpers/Validation/Query.ts
+++ b/src/helpers/Validation/Query.ts
@@ -22,6 +22,15 @@ export default class Query {
         for (let i = 0; i < this.rules.length; i++) {
             const rule = this.rules[i];
 
+            if (rule.whenCallback) {
+                const shouldRun = rule.whenCallback(req);
+
+                if (!shouldRun) {
+                    next();
+                    return;
+                }
+            }
+
             switch (rule.rule) {
                 case ValidationRule.NotEmpty:
                     if (!req.query[rule.field] || req.query[rule.field].length == 0) {
@@ -241,6 +250,14 @@ export default class Query {
         if (rulesLength == 0) return this;
 
         this.rules[rulesLength - 1].errorMessage = message;
+
+        return this;
+    }
+
+    public When(whenCallback: Function): Query {
+        if (this.rules.length == 0) return this;
+
+        this.rules[this.rules.length - 1].whenCallback = whenCallback;
 
         return this;
     }

--- a/src/routes/storage/new.ts
+++ b/src/routes/storage/new.ts
@@ -18,7 +18,8 @@ export default class New extends Page {
             .ChangeField("skuPrefix")
                 .NotEmpty()
             .ChangeField("parentId")
-                .NotEmpty();
+                .NotEmpty()
+                .When((req: Request) => req.body.type != 'building');
 
         super.router.post('/new', UserMiddleware.Authorise, bodyValidation.Validate.bind(bodyValidation), async (req: Request, res: Response) => {
             const type = req.body.type;


### PR DESCRIPTION
- Update validator to only run validation on a callback function
- Update the new storage route to only require parentId when its not a building (top level)

#90 